### PR TITLE
fix: new NFT endpoint

### DIFF
--- a/go/tests/nft_test.go
+++ b/go/tests/nft_test.go
@@ -48,7 +48,7 @@ func TestCreateInvoiceUnpaidNFT(t *testing.T) {
 }
 
 func MintInvoiceUnpaidNFT(t *testing.T, e *httpexpect.Expect, auth string, payload map[string]interface{}) *httpexpect.Object {
-	path := fmt.Sprintf("/token/mint/invoice/unpaid/%s", payload["identifier"])
+	path := fmt.Sprintf("/nfts/%s/invoice/unpaid/mint", payload["identifier"])
 	method := "POST"
 	resp := getResponse(method, path, e, auth, payload).Status(http.StatusOK)
 	assertOkResponse(t, resp)


### PR DESCRIPTION

new endpoint:
https://github.com/centrifuge/go-centrifuge/blob/e46588790de3dbdf0c452f2f3e25efa34e99d36b/protobufs/nft/service.proto#L26